### PR TITLE
Feedback page contents now change on admin status

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -20,8 +20,8 @@ const userController = {
           message: { err },
         });
       })
-  } 
-
+  },
+  
 }
 
 

--- a/server/routes/feedbackRouter.js
+++ b/server/routes/feedbackRouter.js
@@ -7,7 +7,7 @@ feedbackRouter.post('/', postFeedback, (req, res) => {
 })
 
 feedbackRouter.get('/', getFeedback, (req, res) => {
-  return res.status(200).send(res.locals.approvedFeedback);
+  return res.status(200).send(res.locals.feedback);
 })
 
 module.exports = feedbackRouter;


### PR DESCRIPTION
Completed:
Feedback page now queries the database for user admin status to ensure that it is only displaying feedback depending on the user admin status. Admins see all submitted comments. Non-admins only see approved comments. 
To do next: 
Admins will be given the ability to approve messages directly from the front end.
Admins will be able to comment on approved messages. 